### PR TITLE
Fix rc-assets asset scan with no HTML

### DIFF
--- a/bones/scripts/rc-assets.sh
+++ b/bones/scripts/rc-assets.sh
@@ -106,7 +106,7 @@ main() {
     fi
 
     ASSET_PATHS=$(grep -rhoE '(src|href)="\/?assets/[^"]+"' "$OUTPUT_DIR"/*.html 2>/dev/null | \
-        sed -E 's/(src|href)="\/?assets\/([^"]+)"/\2/' | sort | uniq)
+        sed -E 's/(src|href)="\/?assets\/([^"]+)"/\2/' | sort | uniq || true)
 
     asset_count=$(echo "$ASSET_PATHS" | grep -c . || true)
     log "INFO" "Found $asset_count asset references."


### PR DESCRIPTION
## Summary
- prevent rc-assets from failing when no HTML files are present

## Testing
- `bash bones/scripts/rc-test.sh --dry-run` *(fails: Missing required dependency: pandoc)*

------
https://chatgpt.com/codex/tasks/task_e_68482ac4c8388325b89154c6a89b6fd5